### PR TITLE
docs: Add new roles for code review and change acceptance

### DIFF
--- a/content/Roles/_index.md
+++ b/content/Roles/_index.md
@@ -51,6 +51,14 @@ If the *Right Way* to do DevOps is not owned and controlled by an executive then
 
 The EARB is responsible for maintaining the Book of Names. This master list defines all acceptable words and word combinations that may be used for naming things during coding. This ensures that [Code Engineers](/roles/#code-engineer-ce) will not be confused when they join a new Feature Team for the next Convoy. The EARB will meet every 6 weeks to review and reject any new words submitted for inclusion.
 
+## Change Rejection or Acceptance Party (CRAP)
+
+The CRAP is responsible for reviewing all changes and rejecting any changes that do not meet the the iteration standards set by the [Admirals Transformation Office](#admirals-transformation-office-ato). The CRAP will also be responsible for accepting changes that meet the standards and are ready to be included in the next [Convoy](/release-convoy/).
+
+## Review Board Review Board (RBRB)
+
+The RBRB is responsible for reviewing the work of the [Enterprise Architecture Review Board](#enterprise-architecture-review-board-earb) and the [Change Rejection or Acceptance Party](#change-rejection-or-acceptance-party-crap). The RBRB will meet every 26 weeks to review and reject any decisions made by the EARB and CRAP.
+
 ## Feature Captain (FC)
 
 The mid-level manager who is responsible for tracking the progress of the feature they are assigned to.


### PR DESCRIPTION
This pull request introduces changes to the `content/Roles/_index.md` file, specifically adding two new roles in the organization: the Change Rejection or Acceptance Party (CRAP) and the Review Board Review Board (RBRB). These roles are responsible for reviewing changes and decisions made by other boards.

Key changes include:

* [`content/Roles/_index.md`](diffhunk://#diff-b123fcfd9b8ebd99548fde8c36fe9d675d64671144013f16f9588337bafa1e4aR54-R61): Added the role of Change Rejection or Acceptance Party (CRAP), responsible for reviewing all changes and either rejecting those that do not meet iteration standards or accepting those that do.
* [`content/Roles/_index.md`](diffhunk://#diff-b123fcfd9b8ebd99548fde8c36fe9d675d64671144013f16f9588337bafa1e4aR54-R61): Added the role of Review Board Review Board (RBRB), responsible for reviewing the work of the Enterprise Architecture Review Board (EARB) and the CRAP, and rejecting any decisions made by these boards if necessary.